### PR TITLE
feat(code_highlight): 说说模板ajax分页加载完成后重载代码

### DIFF
--- a/src/app/post_list.js
+++ b/src/app/post_list.js
@@ -1,6 +1,7 @@
 import { onlyOnceATime } from "../common/util";
 import { lazyload } from 'lazyload'
 import { __ } from '../common/sakurairo_global'
+import { code_highlight_style } from '../page/index.js'
 
 let load_post_timer;
 const load_post = onlyOnceATime(function load_post() {
@@ -43,6 +44,7 @@ const load_post = onlyOnceATime(function load_post() {
             // $("#pagination a").removeClass("loading").text("Previous");
             // $('#add_post span').removeClass("loading").text("");
             lazyload();
+            code_highlight_style();
             post_list_show_animation();
             document.dispatchEvent(new CustomEvent('ajax_post_loaded',))
             if (nextHref != undefined) {

--- a/src/page/code_highlight.js
+++ b/src/page/code_highlight.js
@@ -53,10 +53,14 @@ export async function hljs_process(pre, code) {
     try {
         await importHighlightjs()
         for (let i = 0; i < code.length; i++) {
-            hljs.highlightElement(code[i]);
+            if (!code[i].classList.contains("hljs")) {
+                hljs.highlightElement(code[i]);
+            }
         }
         for (let i = 0; i < pre.length; i++) {
-            gen_top_bar(pre[i], code[i]);
+            if (!pre[i].classList.contains("highlight-wrap")) {
+                gen_top_bar(pre[i], code[i]);
+            } 
         }
         hljs.initLineNumbersOnLoad();
         document.body.addEventListener("click", hljs_click_callback)
@@ -175,7 +179,9 @@ export async function prism_process(code) {
             loadCommandLine && loadPrismCommandLine()
         ])
         for (const ele of code) {
-            Prism.highlightElement(ele)
+            if (!ele.firstChild?.classList?.contains('token')) {
+                Prism.highlightElement(ele);
+              }
         }
         Prism.plugins.fileHighlight && Prism.plugins.fileHighlight.highlight()
     } catch (error) {

--- a/src/page/index.js
+++ b/src/page/index.js
@@ -10,7 +10,7 @@ import { _$, __ } from '../common/sakurairo_global'
 import load_bangumi from './bangumi'
 import { importExternal } from '../common/npmLib'
 import debounce from '@mui/utils/debounce'
-async function code_highlight_style() {
+export async function code_highlight_style() {
     const pre = document.getElementsByTagName("pre"),
         code = document.querySelectorAll("pre code");
     if (!pre.length) {
@@ -38,6 +38,12 @@ async function code_highlight_style() {
     //copy_code_block
     if (code.length > 0) {
         for (let j = 0; j < code.length; j++) {
+            const pre_a = code[j].parentElement.querySelectorAll("a");
+            for (const ele of pre_a) {
+                if (ele.classList.contains("copy-code")) {
+                    ele.remove(); //如果已经存在复制按钮，需将其移除后再重新添加
+                }
+            }
             code[j].setAttribute('id', 'code-block-' + j);
             code[j].insertAdjacentHTML('afterend', '<a class="copy-code" href="javascript:" data-clipboard-target="#code-block-' + j + '" title="' + __("拷贝代码") + '"><i class="fa-regular fa-clipboard"></i>');
         }


### PR DESCRIPTION
对于Highlight.js，需要排除已经高亮完成的代码块，否则会报错{"One of your code blocks includes unescaped HTML" (XSS attack vector)}。
虽然Prism.js没有像Highligh.js一样的问题，但还是排除了已经高亮完成的部分。
两种高亮方式都存在高亮完成后重复添加复制按钮的情况，重载代码高亮时需要移除已添加的按钮，并重新添加。