### PR TITLE
尝试修复了baguetteBox不能用的问题

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -22,7 +22,7 @@ declare namespace _iro {
     const NProgressON: boolean
     const audio: boolean
     const author_name: string
-    const baguetteBoxON: boolean
+    const baguetteBox: boolean
     const fancybox: boolean
     const lightGallery:  Record<string, unknown> | false | undefined
     const clipboardRef: boolean

--- a/src/page/artile_attachment/index.ts
+++ b/src/page/artile_attachment/index.ts
@@ -33,7 +33,7 @@ function collapse() {
 let lightBoxCSS: HTMLLinkElement
 async function lightbox() {
     //init lightbox
-    if (_iro.baguetteBoxON) {
+    if (_iro.baguetteBox) {
         if (!lightBoxCSS) lightBoxCSS = loadCSS(resolvePath('dist/baguetteBox.min.css', 'baguettebox.js', '1.11.1'))
         //@ts-ignore
         const { default: baguetteBox } = await import('baguettebox.js')


### PR DESCRIPTION
通过开关各个灯箱找不同发现在_iro中这几个开关的名字分别是fancybox、baguetteBox

不过切到baguetteBox其对应的主内容并没有被加载

看源内容baguetteBox相比其他两个多了个ON，去掉后重新打包覆盖好像就能用了

![image](https://github.com/user-attachments/assets/868e756b-828c-41d3-82f8-7cbee44399a2)
