### PR TITLE
使用伪a标签修复实时搜索点击不跳转的问题，ghcard添加自动深色模式

### DIFF
--- a/src/app/search.ts
+++ b/src/app/search.ts
@@ -116,6 +116,8 @@ function div_href() {
             Ty.href = ele.getAttribute('href')
             let adiv = document.createElement("a")
             adiv.href = Ty.href
+            adiv.style.display = "none"
+            document.body.appendChild(adiv)
             adiv.click()
             Ty.click()
             search_close.click()

--- a/src/app/search.ts
+++ b/src/app/search.ts
@@ -114,6 +114,9 @@ function div_href() {
     for (const ele of document.getElementsByClassName('ins-selectable')) {
         ele.addEventListener("click", () => {
             Ty.href = ele.getAttribute('href')
+            let adiv = document.createElement("a")
+            adiv.href = Ty.href
+            adiv.click()
             Ty.click()
             search_close.click()
         });

--- a/src/page/ghcard_theme.js
+++ b/src/page/ghcard_theme.js
@@ -1,0 +1,50 @@
+import {ifDarkmodeShouldOn} from '../app/darkmode'
+
+export default function ghcardTheme(){
+    document.addEventListener('darkmode', (event) => { // darkmode.ts informDarkModeChange事件通知
+        let turn = event.detail;
+        ghcardDark(turn);
+    });
+    document.addEventListener('pjax:complete',function(){
+        checkDark()
+    })
+    checkDark()
+}
+
+function checkDark () {
+    const dark = localStorage.getItem("dark")
+    if (!dark) {
+        if (ifDarkmodeShouldOn() && _iro.darkmode) {
+            ghcardDark(true);
+        } else {
+            ghcardDark(false);
+        }
+    } else {
+        if (dark == '1') {
+            ghcardDark(true);
+        } else {
+            ghcardDark(false);
+        }
+    }
+}
+
+function ghcardDark (turn = false) {
+    let cards = document.querySelectorAll('.ghcard');
+    if (!cards) return;
+    cards.forEach((ghcard) => {
+        let card = ghcard.querySelector('img')
+        if (!card) return;
+        let src = new URL(card.src)
+        try{
+            if (turn) {
+                src.searchParams.set('theme','dark')
+                card.src = src.toString()
+            } else {
+                src.searchParams.delete('theme')
+                card.src = src.toString()
+            }
+        } catch(e){
+            // none
+        }
+    });
+}

--- a/src/page/index.js
+++ b/src/page/index.js
@@ -13,6 +13,7 @@ import prepareEmoji from './emoji'
 import initAnnotations from './annotation'
 import initLinkSubmission from './link_form'
 import init_steamCard from './steam_card'
+import ghcardTheme from './ghcard_theme'
 
 function apply_post_theme_color() {
     if (_iro.post_theme_color != false && _iro.post_theme_color != 'false') {
@@ -459,6 +460,7 @@ function whileReady() {
     XCP()
     getqqinfo()
     add_upload_tips()
+    ghcardTheme()
 }
 function whilePjaxComplete() {
     try {


### PR DESCRIPTION
原先实时搜索点击后异常不跳转，现在通过创建一个伪a标签修复此问题

不直接改为a标签是因为会导致排版出现问题

github仓库卡片会在适当时机自动变为深色主题