### PR TITLE
fix:修复代码高亮会异常污染wp预格式区块的问题

### DIFF
--- a/src/common/code-highlight.js
+++ b/src/common/code-highlight.js
@@ -192,7 +192,7 @@ export async function prism_process(code) {
 }
 
 export async function code_highlight_style() {
-    const pre = document.getElementsByTagName("pre"),
+    const pre = document.querySelectorAll("pre:has(code)"),
         code = document.querySelectorAll("pre code");
     if (!pre.length) {
         switch (_iro.code_highlight) {


### PR DESCRIPTION
https://github.com/mirai-mamori/Sakurairo/issues/1401