### PR TITLE
fix: 评论私密接口未授权风险和无法切换私密状态

### DIFF
--- a/src/page/index.js
+++ b/src/page/index.js
@@ -236,17 +236,13 @@ function sm() {
         cm.addEventListener("click", (e) => {
             let list = e.target.parentNode;
             if (list.classList.contains("sm")) {
-                let msg = __("您真的要设为私密吗？");
+                let msg = __("您确定要切换私密状态吗？");
                 if (confirm(msg) == true) {
-                    if (list.classList.contains('private_now')) {
-                        alert(__('您之前已设过私密评论'));
-                        return false;
-                    } else {
-                        list.classList.add('private_now');
                         let idp = list.getAttribute("data-idp"),
                             actionp = list.getAttribute("data-actionp"),
-                            rateHolderp = list.getElementsByClassName('has_set_private')[0];
-                        let ajax_data = "action=siren_private&p_id=" + idp + "&p_action=" + actionp;
+                            rateHolderp = list.getElementsByClassName('has_set_private')[0],
+                            noncep = list.getAttribute("data-noncep");
+                        let ajax_data = "action=siren_private&p_id=" + idp + "&p_action=" + actionp + "&_wpnonce=" + noncep;
                         let request = new XMLHttpRequest();
                         request.onreadystatechange = function () {
                             if (this.readyState == 4 && this.status == 200) {
@@ -257,7 +253,6 @@ function sm() {
                         request.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
                         request.send(ajax_data);
                         return false;
-                    }
                 }
             }
         })


### PR DESCRIPTION
# 演示

## 1. 评论私密接口未授权风险

所有评论的私密状态可以随意被更改

评论私密切换接口同时注册了未登录 AJAX 入口，并且请求不需要 nonce：

```php
add_action('wp_ajax_nopriv_siren_private', 'siren_private');
add_action('wp_ajax_siren_private', 'siren_private');
```

 REST API 获取最近评论 ID：

```text
GET /wp-json/wp/v2/comments?per_page=XXXX&orderby=date&order=desc
```

返回第一项里的 `id` 即为后续 AJAX 请求的 `p_id`：

![image-20260809192359670](https://ranfey-typora.oss-cn-chengdu.aliyuncs.com/image-20260809192359670.png)

可构造请求：

```text
POST /wp-admin/admin-ajax.php
action=siren_private&p_id=XXXX&p_action=set_private
```

![image-20260809191614579](https://ranfey-typora.oss-cn-chengdu.aliyuncs.com/image-20260809191614579.png)

## 2. 评论私密状态无法正确切换

只会写入私密状态：

```php
update_comment_meta($comment_id, '_private', 'true');
```

评论只能被设为私密，不能再次点击恢复公开

![recording](https://ranfey-typora.oss-cn-chengdu.aliyuncs.com/20260809235345032.gif)

# 修复内容

对应

https://github.com/mirai-mamori/Sakurairo/pull/1422

### `src/page/index.js`

- 从按钮读取 `data-noncep`：

- AJAX 请求追加 `_wpnonce`：

```js
let ajax_data = "action=siren_private&p_id=" + idp + "&p_action=" + actionp + "&_wpnonce=" + noncep;
```

- 移除 `private_now` 判断
- 确认文案改为“您确定要切换私密状态吗？”

# 验证

修复后

![recording](https://ranfey-typora.oss-cn-chengdu.aliyuncs.com/20260809235358523.gif)

![image-20260809194938004](https://ranfey-typora.oss-cn-chengdu.aliyuncs.com/image-20260809194938004.png)
